### PR TITLE
feat: implement AWS ALB-terminated HTTPS configuration (DOM-21)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-security:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
     implementation(project(":backend:presentation:api"))
 }
 

--- a/backend/src/main/kotlin/com/example/config/SecurityConfiguration.kt
+++ b/backend/src/main/kotlin/com/example/config/SecurityConfiguration.kt
@@ -1,0 +1,81 @@
+package com.example.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfiguration {
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        return http
+            .sessionManagement { session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+            .headers { headers ->
+                headers
+                    // HSTS (ALB終端でHTTPS → HTTP変換されるため、プロキシ対応が必要)
+                    .httpStrictTransportSecurity { hstsConfig ->
+                        hstsConfig
+                            .maxAgeInSeconds(31536000) // 1年
+                            .includeSubDomains(true)
+                            .preload(true)
+                    }
+                    // X-Frame-Options (クリックジャッキング対策)
+                    .frameOptions { frameOptions ->
+                        frameOptions.deny()
+                    }
+                    // X-Content-Type-Options (MIME sniffing攻撃対策)
+                    .contentTypeOptions { }
+                    // Referrer Policy
+                    .referrerPolicy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN)
+                    // X-XSS-Protection (レガシーブラウザ対応)
+                    .and()
+                    .addHeaderWriter { request, response ->
+                        response.setHeader("X-XSS-Protection", "1; mode=block")
+                        // Permissions Policy (旧Feature Policy)
+                        response.setHeader(
+                            "Permissions-Policy", 
+                            "geolocation=(), camera=(), microphone=(), payment=(), usb=(), vr=(), accelerometer=(), gyroscope=(), magnetometer=(), clipboard-read=(), clipboard-write=()"
+                        )
+                        // Content Security Policy
+                        response.setHeader(
+                            "Content-Security-Policy",
+                            "default-src 'self'; " +
+                            "script-src 'self'; " +
+                            "style-src 'self' 'unsafe-inline'; " +
+                            "img-src 'self' data: https:; " +
+                            "connect-src 'self'; " +
+                            "font-src 'self'; " +
+                            "object-src 'none'; " +
+                            "media-src 'self'; " +
+                            "frame-src 'none'"
+                        )
+                    }
+            }
+            .authorizeHttpRequests { auth ->
+                auth
+                    // ヘルスチェックエンドポイント（ALB用）
+                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                    // GraphQLエンドポイント（将来的に認証必須にする予定）
+                    .requestMatchers("/graphql").permitAll()
+                    // その他すべてのリクエストは認証必須
+                    .anyRequest().authenticated()
+            }
+            .csrf { csrf ->
+                // GraphQL APIのためCSRFを無効化（JWTで認証予定）
+                csrf.disable()
+            }
+            .cors { cors ->
+                // CORSは application.yml で設定
+                cors.configurationSource { null }
+            }
+            .build()
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,84 @@
+server:
+  # ALBからのHTTPトラフィックを受信
+  port: 8080
+  # ALBプロキシヘッダーを信頼
+  forward-headers-strategy: framework
+
+spring:
+  application:
+    name: domestic-accounts-booking
+  
+  # GraphQL設定
+  graphql:
+    websocket:
+      connection-init-timeout: 60s
+    
+  # プロキシ信頼設定（ALB対応）
+  web:
+    # ALBからのX-Forwarded-*ヘッダーを信頼
+    trust-proxy: true
+
+# Spring Boot Actuator（ヘルスチェック用）
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: when-authorized
+  server:
+    # セキュリティヘッダー設定
+    add-application-context-header: false
+
+# ログ設定
+logging:
+  level:
+    org.springframework.web: INFO
+    org.springframework.security: INFO
+    root: INFO
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
+
+---
+# 開発環境設定
+spring:
+  config:
+    activate:
+      on-profile: dev
+  
+  # 開発環境でのCORS設定（必要に応じて）
+  web:
+    cors:
+      allowed-origins: "http://localhost:3000"
+      allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
+      allowed-headers: "*"
+      allow-credentials: true
+
+logging:
+  level:
+    org.springframework.web: DEBUG
+    root: DEBUG
+
+---
+# 本番環境設定
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+# 本番環境でのセキュリティ強化
+management:
+  endpoint:
+    health:
+      show-details: never
+  endpoints:
+    web:
+      exposure:
+        include: health
+
+logging:
+  level:
+    root: WARN
+    org.springframework.security: INFO

--- a/docs/09_deployment/aws-https-setup.md
+++ b/docs/09_deployment/aws-https-setup.md
@@ -1,0 +1,217 @@
+# AWS環境でのHTTPS設定と動作確認
+
+## 概要
+
+このドキュメントでは、AWS環境での家計簿システムのHTTPS設定について説明します。
+AWS ALBでSSL終端を行い、Spring BootアプリケーションはHTTPで動作する構成となります。
+
+## 1. AWS構成要件
+
+### 1.1 Route53設定
+- ドメインの登録・管理
+- ALBへのAレコード設定
+
+### 1.2 ALB (Application Load Balancer) 設定
+
+**リスナー設定:**
+```
+HTTPS (443) → Target Group (HTTP:8080)
+- SSL Policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+- 証明書: AWS Certificate Manager (ACM)
+```
+
+**Target Group設定:**
+```
+Protocol: HTTP
+Port: 8080
+Health Check:
+  - Path: /actuator/health  
+  - Protocol: HTTP
+  - Port: 8080
+  - Healthy threshold: 2
+  - Unhealthy threshold: 3
+  - Timeout: 5 seconds
+  - Interval: 30 seconds
+```
+
+### 1.3 Security Group設定
+
+**ALB Security Group:**
+- Inbound: 443 (HTTPS) from 0.0.0.0/0
+- Outbound: 8080 (HTTP) to ECS Task Security Group
+
+**ECS Task Security Group:**
+- Inbound: 8080 (HTTP) from ALB Security Group
+- Outbound: All traffic
+
+## 2. Spring Boot設定
+
+### 2.1 application.yml設定
+
+```yaml
+server:
+  port: 8080
+  forward-headers-strategy: framework
+
+spring:
+  web:
+    trust-proxy: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+      base-path: /actuator
+```
+
+### 2.2 SecurityConfiguration
+
+- ALBプロキシヘッダー対応
+- セキュリティヘッダー設定（HSTS、CSP、X-Frame-Options等）
+- ヘルスチェックエンドポイントのパブリックアクセス
+
+## 3. 動作確認方法
+
+### 3.1 開発環境での確認
+
+**ローカル起動:**
+```bash
+cd backend
+./gradlew bootRun
+```
+
+**ヘルスチェック確認:**
+```bash
+curl http://localhost:8080/actuator/health
+# 期待する応答: {"status":"UP"}
+```
+
+**セキュリティヘッダー確認:**
+```bash
+curl -I http://localhost:8080/actuator/health
+# 確認項目:
+# - X-Frame-Options: DENY
+# - X-Content-Type-Options: nosniff
+# - Content-Security-Policy: default-src 'self'; ...
+```
+
+### 3.2 AWS環境での確認
+
+**ALB経由のHTTPS確認:**
+```bash
+# ALBのDNS名を使用
+curl -I https://your-alb-dns-name.elb.amazonaws.com/actuator/health
+
+# Route53ドメインを使用
+curl -I https://yourdomain.com/actuator/health
+```
+
+**期待するレスポンスヘッダー:**
+```
+HTTP/2 200
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+x-frame-options: DENY
+x-content-type-options: nosniff
+referrer-policy: strict-origin-when-cross-origin
+content-security-policy: default-src 'self'; ...
+permissions-policy: geolocation=(), camera=(), microphone=()...
+```
+
+### 3.3 GraphQL エンドポイント確認
+
+**GraphQL Playground/Introspection:**
+```bash
+curl -X POST https://yourdomain.com/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ __schema { types { name } } }"}'
+```
+
+### 3.4 SSL証明書確認
+
+**証明書情報確認:**
+```bash
+openssl s_client -connect yourdomain.com:443 -servername yourdomain.com < /dev/null 2>/dev/null | openssl x509 -text -noout
+
+# 確認項目:
+# - TLS 1.3対応
+# - 証明書有効期限
+# - Subject Alternative Names
+```
+
+### 3.5 セキュリティテスト
+
+**SSL Labs テスト:**
+- https://www.ssllabs.com/ssltest/
+- A+グレード取得を目標
+
+**HSTS確認:**
+```bash
+curl -I https://yourdomain.com
+# strict-transport-security ヘッダーの存在確認
+```
+
+## 4. トラブルシューティング
+
+### 4.1 よくある問題
+
+**1. ALBヘルスチェック失敗**
+```bash
+# ECS Taskログ確認
+aws logs get-log-events --log-group-name /ecs/your-task-definition
+
+# ポート8080での接続確認
+telnet your-ecs-task-ip 8080
+```
+
+**2. プロキシヘッダー問題**
+```yaml
+# application.yml に追加
+server:
+  forward-headers-strategy: framework
+logging:
+  level:
+    org.springframework.web: DEBUG
+```
+
+**3. CORS問題**
+```yaml
+# 開発環境でのCORS設定
+spring:
+  web:
+    cors:
+      allowed-origins: "https://yourdomain.com"
+```
+
+### 4.2 デバッグ用エンドポイント
+
+**リクエストヘッダー確認用:**
+```kotlin
+@RestController
+class DebugController {
+    @GetMapping("/debug/headers")
+    fun headers(request: HttpServletRequest): Map<String, String> {
+        return request.headerNames.asSequence()
+            .associateWith { request.getHeader(it) }
+    }
+}
+```
+
+## 5. 本番環境移行チェックリスト
+
+- [ ] Route53ドメイン設定完了
+- [ ] ACM証明書発行・検証完了
+- [ ] ALB設定完了（HTTPS → HTTP転送）
+- [ ] Target Group設定完了
+- [ ] Security Group設定完了
+- [ ] ECS Task定義更新
+- [ ] ヘルスチェック正常動作確認
+- [ ] SSL Labs A+グレード確認
+- [ ] GraphQL API動作確認
+- [ ] セキュリティヘッダー動作確認
+
+## 関連ドキュメント
+
+- [セキュリティ要件定義](../11_security/security-requirements.md)
+- [バックエンドアーキテクチャ](../03_architecture/backend-architecture.md)
+- [セキュリティテスト計画](../11_security/security-testing.md)

--- a/docs/11_security/security-requirements.md
+++ b/docs/11_security/security-requirements.md
@@ -1,0 +1,276 @@
+# セキュリティ要件定義
+
+このドキュメントでは、家計簿システムの包括的なセキュリティ要件を定義します。
+
+## 概要
+
+家計簿システムは個人の金融情報を扱うため、高いセキュリティレベルが求められます。本仕様では、データ保護、通信セキュリティ、認証・認可、および各種攻撃対策を定義します。
+
+## 1. データ暗号化要件
+
+### 1.1 個人情報の暗号化
+
+**対象データ:**
+- ユーザーのメールアドレス
+- 金額情報
+- 取引先情報
+- メモ・説明文（個人情報が含まれる可能性）
+
+**暗号化方式:**
+- **データベース内暗号化**: AES-256-GCM
+- **パスワード**: bcrypt (cost factor: 12)
+- **機密性の高いデータ**: Spring Security Crypto による透過的暗号化
+
+**キー管理:**
+- 環境変数による暗号化キー管理
+- 本番環境: AWS Secrets Manager / HashiCorp Vault の使用を推奨
+- 開発環境: `.env` ファイル（Git管理外）
+
+### 1.2 データベースセキュリティ
+
+**MySQL設定:**
+```sql
+-- TLS接続の強制
+REQUIRE SSL;
+
+-- データ暗号化
+CREATE TABLE users (
+    id BIGINT PRIMARY KEY,
+    email VARCHAR(255) ENCRYPTED,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+## 2. 通信セキュリティ
+
+### 2.1 HTTPS/TLS (AWS ALB終端)
+
+**AWS構成要件:**
+- **Route53**: ドメイン管理
+- **ALB (Application Load Balancer)**: SSL終端処理
+- **TLS 1.3** 必須（ALB設定）
+- **証明書**: AWS Certificate Manager (ACM) による自動管理
+
+**Spring Boot設定（ALBプロキシ対応）:**
+```yaml
+server:
+  # HTTPで動作（ALBがHTTPS終端）
+  port: 8080
+  forward-headers-strategy: framework
+  
+spring:
+  # プロキシヘッダー信頼設定
+  web:
+    trust-proxy: true
+```
+
+**ALB設定要件:**
+- SSL Policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+- HTTPS Listener (443) → HTTP Target (8080)
+- Health Check: HTTP:/target:8080/actuator/health
+
+**セキュリティヘッダー（Spring Boot側で設定）:**
+```yaml
+# HSTS等のセキュリティヘッダーは引き続きアプリケーションで設定
+management:
+  server:
+    add-application-context-header: false
+```
+
+### 2.2 GraphQL セキュリティ
+
+**認証:**
+- JWT (JSON Web Token) による認証
+- Access Token（15分）+ Refresh Token（7日）方式
+
+**認可:**
+- GraphQL スキーマレベルでの認可チェック
+- フィールドレベルでのアクセス制御
+
+**クエリ制限:**
+- Query depth 制限（最大10レベル）
+- Query complexity 制限（最大1000ポイント）
+- Query timeout（30秒）
+
+## 3. 認証・認可
+
+### 3.1 認証方式
+
+**JWT設定:**
+```yaml
+security:
+  jwt:
+    secret: ${JWT_SECRET}  # 最低256bit
+    access-token-expiry: 900  # 15分
+    refresh-token-expiry: 604800  # 7日
+```
+
+**Spring Security設定:**
+- `/graphql` エンドポイントは認証必須
+- `/health`, `/metrics` エンドポイントは認証不要
+
+### 3.2 認可ポリシー
+
+**ユーザー別データアクセス:**
+- ユーザーは自分の作成したExpenseのみアクセス可能
+- 管理者権限は当面不要
+
+## 4. 入力値検証・SQL インジェクション対策
+
+### 4.1 バックエンド検証
+
+**Kotlin Bean Validation:**
+```kotlin
+data class ExpenseInput(
+    @field:NotBlank
+    @field:Size(max = 255)
+    val description: String,
+    
+    @field:Positive
+    @field:Digits(integer = 10, fraction = 2)
+    val amount: BigDecimal,
+    
+    @field:Pattern(regexp = "^[a-zA-Z0-9\\s\\-_]+$")
+    val category: String
+)
+```
+
+**GraphQL Validation:**
+- Spring Boot Validation との統合
+- カスタムバリデーターによる業務ルール検証
+
+### 4.2 JOOQ による SQL インジェクション対策
+
+**現在の構成（JOOQ）での対策:**
+- Prepared Statement の自動使用
+- 動的クエリ構築時のパラメータバインディング強制
+
+```kotlin
+// 安全なクエリ例
+context.select()
+    .from(EXPENSE)
+    .where(EXPENSE.USER_ID.eq(userId))  // パラメータバインディング
+    .and(EXPENSE.AMOUNT.greaterThan(amount))
+    .fetch()
+```
+
+## 5. フロントエンド（Remix）セキュリティ
+
+### 5.1 CSRF 対策
+
+**Remix CSRF Token:**
+```typescript
+// app/utils/csrf.server.ts
+import { createCookie } from "@remix-run/node";
+
+export const csrfToken = createCookie("csrf", {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "strict",
+});
+```
+
+### 5.2 XSS 対策
+
+**Content Security Policy (CSP):**
+```typescript
+// app/root.tsx
+export const headers = {
+  "Content-Security-Policy": 
+    "default-src 'self'; " +
+    "script-src 'self' 'unsafe-inline'; " +
+    "style-src 'self' 'unsafe-inline'; " +
+    "img-src 'self' data: https:; " +
+    "connect-src 'self' https://api.example.com"
+};
+```
+
+**入力値サニタイゼーション:**
+- DOMPurify によるHTMLサニタイゼーション
+- GraphQL レスポンスの自動エスケープ
+
+### 5.3 セキュリティヘッダー
+
+```typescript
+// セキュリティヘッダーの設定
+export const headers = {
+  "X-Frame-Options": "DENY",
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "geolocation=(), camera=(), microphone=()"
+};
+```
+
+## 6. レート制限
+
+### 6.1 API レート制限
+
+**GraphQL エンドポイント:**
+- 一般ユーザー: 100 requests/分
+- 認証失敗: 5 attempts/15分（アカウントロック）
+
+**Spring Boot レート制限:**
+```yaml
+spring:
+  security:
+    rate-limit:
+      graphql:
+        requests-per-minute: 100
+      auth:
+        failed-attempts: 5
+        lockout-duration: 900  # 15分
+```
+
+### 6.2 Redis による分散レート制限
+
+**実装:**
+- Redis Sliding Window アルゴリズム
+- ユーザーID + IPアドレス による制限
+
+## 7. ログ・監査
+
+### 7.1 セキュリティログ
+
+**記録対象:**
+- 認証成功/失敗
+- 不正なアクセス試行
+- データアクセスパターンの異常
+
+**ログフォーマット:**
+```json
+{
+  "timestamp": "2024-01-01T00:00:00Z",
+  "level": "WARN",
+  "event": "AUTHENTICATION_FAILURE",
+  "userId": null,
+  "ipAddress": "192.168.1.1",
+  "userAgent": "Mozilla/5.0...",
+  "details": "Invalid password attempt"
+}
+```
+
+### 7.2 個人情報ログ除外
+
+- パスワード、金額、個人情報をログに出力しない
+- ログ構造化による機密情報フィルタリング
+
+## 8. 開発・運用セキュリティ
+
+### 8.1 依存関係管理
+
+**自動脆弱性チェック:**
+- `npm audit` （フロントエンド）
+- Gradle dependency vulnerability scan
+- GitHub Dependabot によるアップデート
+
+### 8.2 CI/CD セキュリティ
+
+**GitHub Actions:**
+- Secrets による機密情報管理
+- OIDC による AWS認証（長期的なアクセスキー排除）
+
+## 関連ドキュメント
+
+- [認証・認可詳細設計](./auth-design.md)
+- [暗号化実装ガイド](./encryption-guide.md)
+- [セキュリティテスト計画](./security-testing.md)


### PR DESCRIPTION
## Summary
- Implement Spring Boot security configuration for AWS ALB-terminated HTTPS setup
- Add comprehensive security headers (HSTS, CSP, X-Frame-Options, etc.)
- Configure ALB proxy support with forward-headers-strategy
- Update security documentation for AWS infrastructure requirements

## Test plan
- [x] Spring Boot application builds successfully
- [x] Security configuration compiles without errors
- [ ] Deploy to AWS environment and verify ALB → Spring Boot HTTP communication
- [ ] Verify security headers are properly set in HTTP responses
- [ ] Confirm health check endpoint (/actuator/health) works through ALB
- [ ] Test GraphQL endpoint accessibility through HTTPS

🤖 Generated with [Claude Code](https://claude.ai/code)
